### PR TITLE
Ranch integration

### DIFF
--- a/include/tls_bench.hrl
+++ b/include/tls_bench.hrl
@@ -29,3 +29,9 @@
 
 -define(CRITICAL_MSG(Format, Args),
     io:format("CRITICAL "++Format++"~n", Args)).
+
+%% ranch socket
+-record(essl_socket, {socket, mod, options}).
+
+%% P1 socket
+-record(tlssock, {tcpsock :: inet:socket(), tlsport :: port()}).

--- a/rebar.config
+++ b/rebar.config
@@ -6,5 +6,7 @@
     %{plists, ".*", {git, "https://github.com/silviucpp/plists.git", {tag, "1.1.2"}}},
     {p1_tls, ".*", {git, "https://github.com/processone/tls.git", "6b09ed76342529aad4e61bb298e97bf17ec136f5"}},
     {fast_tls, ".*", {git, "https://github.com/processone/fast_tls.git", {tag, "1.0.7"}}},
-    {etls, ".*", {git, "https://github.com/kzemek/etls.git", "a915ece167564015a555ca3a69e508ef82d00ad0"}}
+    %%{etls, ".*", {git, "https://github.com/kzemek/etls.git", "a915ece167564015a555ca3a69e508ef82d00ad0"}}
+    {ranch, ".*", {git, "git@github.com:ninenines/ranch.git", {branch, "master"}}},
+    {eper, ".*", {git, "git@github.com:massemanet/eper.git", {branch, "master"}}}
 ]}.

--- a/src/benchmarks/essl.erl
+++ b/src/benchmarks/essl.erl
@@ -4,10 +4,9 @@
 -include("tls_bench.hrl").
 
 -record(state, {socket, mod, tls_opt}).
--record(tlssock, {tcpsock :: inet:socket(), tlsport :: port()}).
 
 -export([
-    connect/6,
+    connect/5,
     listen/4,
     accept/1,
     handshake/1,
@@ -20,22 +19,22 @@
     recv/2
 ]).
 
-connect(Mod, Host, Port, TcpOptions, TlsOptions, Timeout) ->
+connect(Mod, Host, Port, Options, Timeout) ->
     Resp = case Mod of
         ?MOD_ETLS ->
-            etls:connect(Host, Port, TcpOptions ++ TlsOptions, Timeout);
+            etls:connect(Host, Port, Options, Timeout);
         ?MOD_FAST_TLS ->
-            {ok, TcpSocket} = gen_tcp:connect(Host, Port, TcpOptions, Timeout),
-            {ok, TlsSocket} = fast_tls:tcp_to_tls(TcpSocket, [connect|TlsOptions]),
+            {ok, TcpSocket} = gen_tcp:connect(Host, Port, Options, Timeout),
+            {ok, TlsSocket} = fast_tls:tcp_to_tls(TcpSocket, [connect|Options]),
             {ok, TlsSocket};
         ?MOD_P1_TLS ->
-            {ok, TcpSocket} = gen_tcp:connect(Host, Port, TcpOptions, Timeout),
-            {ok, TlsSocket} = p1_tls:tcp_to_tls(TcpSocket, [connect|TlsOptions]),
+            {ok, TcpSocket} = gen_tcp:connect(Host, Port, Options, Timeout),
+            {ok, TlsSocket} = p1_tls:tcp_to_tls(TcpSocket, [connect|Options]),
             {ok, TlsSocket};
         ?MOD_SSL ->
-            ssl:connect(Host, Port, TcpOptions ++ TlsOptions, Timeout);
+            ssl:connect(Host, Port, Options, Timeout);
         ?MOD_TCP ->
-            gen_tcp:connect(Host, Port, TcpOptions, Timeout)
+            gen_tcp:connect(Host, Port, Options, Timeout)
     end,
 
     case Resp of

--- a/src/benchmarks/ranch_essl.erl
+++ b/src/benchmarks/ranch_essl.erl
@@ -1,0 +1,240 @@
+-module(ranch_essl).
+-author("silviu.caragea").
+
+-include("tls_bench.hrl").
+
+%% Ranch callbacks
+-export([name/0]).
+-export([secure/0]).
+-export([messages/0]).
+-export([listen/1]).
+-export([disallowed_listen_options/0]).
+-export([accept/2]).
+-export([accept_ack/2]).
+-export([connect/3]).
+-export([connect/4]).
+-export([recv/3]).
+-export([send/2]).
+-export([setopts/2]).
+-export([controlling_process/2]).
+-export([peername/1]).
+-export([sockname/1]).
+-export([shutdown/2]).
+-export([close/1]).
+
+%% Utility functions
+-export([connect/5]).
+
+
+
+name() -> essl.
+secure() -> true.
+messages() -> {essl, essl_closed, essl_error}.
+disallowed_listen_options() -> [].
+
+
+connect(Host, Port, Options) ->
+  connect(Host, Port, Options, infinity).
+
+
+connect(Host, Port, Options, Timeout) ->
+    Mod = tlsb_utils:lookup(impl, Options), 
+    TransportOpts = lists:keydelete(impl, 1, Options),
+    case connect(Mod, Host, Port, TransportOpts, Timeout) of
+      {ok, Socket} -> {ok, #essl_socket{socket = Socket, mod = Mod, options = TransportOpts}};
+      Error -> Error
+    end.
+
+connect(?MOD_ETLS, Host, Port, Options, Timeout) ->
+    ranch_etls:connect(Host, Port, Options, Timeout);
+
+connect(P1_Mod, Host, Port, Options, Timeout) when P1_Mod == ?MOD_FAST_TLS orelse P1_Mod == ?MOD_P1_TLS ->
+            {ok, TcpSocket} = ranch_tcp:connect(Host, Port, lists:keydelete(tls_opt, 1, Options), Timeout),
+            TlsOpts = tlsb_utils:lookup(tls_opt, Options),
+            {ok, _TlsSocket} = P1_Mod:tcp_to_tls(TcpSocket, [connect|TlsOpts]);
+
+connect(?MOD_SSL, Host, Port, Options, Timeout) ->
+            ranch_ssl:connect(Host, Port, Options, Timeout);
+
+connect(?MOD_TCP, Host, Port, Options, Timeout) ->
+            ranch_tcp:connect(Host, Port, Options, Timeout).
+
+
+listen(Options) ->
+  Mod = tlsb_utils:lookup(impl, Options),
+  TransportOpts = lists:keydelete(impl, 1, Options),
+  case listen(Mod, TransportOpts) of
+    {ok, Socket} -> {ok, #essl_socket{socket = Socket, mod = Mod, options = TransportOpts}};
+    Error -> Error
+  end.
+
+listen(?MOD_ETLS, Options) ->
+    ranch_etls:listen(Options);
+
+listen(?MOD_SSL, Options) ->
+    ranch_ssl:listen(Options);
+
+
+listen(P1_Mod, Options) when P1_Mod == ?MOD_FAST_TLS orelse P1_Mod == ?MOD_P1_TLS ->
+  ranch_tcp:listen(lists:keydelete(tls_opt, 1, Options));
+
+listen(?MOD_SSL, Options) ->
+  ranch_ssl:listen(Options);
+
+listen(gen_tcp, Options) ->
+    ranch_tcp:listen(Options).
+
+accept(LSocket, Timeout) ->
+  case accept1(LSocket, Timeout) of
+    {ok, Socket} -> {ok, LSocket#essl_socket{socket = Socket}};
+    Error -> Error
+  end.
+
+accept1(#essl_socket{socket = LSocket, mod = ?MOD_ETLS}, Timeout) ->
+            ranch_etls:accept(LSocket, Timeout);
+
+accept1(#essl_socket{socket = LSocket, mod = ?MOD_SSL}, Timeout) ->
+    ranch_ssl:accept(LSocket, Timeout);
+
+accept1(#essl_socket{socket = LSocket, mod = P1_Mod, options = Options}, Timeout)
+  when P1_Mod == ?MOD_FAST_TLS orelse P1_Mod == ?MOD_P1_TLS ->
+  case gen_tcp:accept(LSocket, Timeout) of
+    {ok, TCPSocket} -> P1_Mod:tcp_to_tls(TCPSocket, tlsb_utils:lookup(tls_opt, Options));
+    Error -> Error
+  end; 
+
+accept1(#essl_socket{socket = LSocket, mod = ?MOD_TCP}, Timeout) ->
+    ranch_tcp:accept(LSocket, Timeout).
+
+accept_ack(Socket, Timeout) ->
+  case accept_ack1(Socket, Timeout) of
+    ok -> {ok, Socket};
+    {ok, UpgradedSocket} when is_record(UpgradedSocket, essl_socket) ->
+      {ok, UpgradedSocket};
+    {ok, UpgradedSocket} ->
+      {ok, Socket#essl_socket{socket = UpgradedSocket}};
+    Error
+      -> Error
+  end.
+
+accept_ack1(#essl_socket{socket = LSocket, mod = ?MOD_ETLS}, Timeout) ->
+    ok = ranch_etls:accept_ack(LSocket, Timeout);
+
+accept_ack1(#essl_socket{socket = LSocket, mod = ?MOD_SSL}, Timeout) ->
+    ok = ranch_ssl:accept_ack(LSocket, Timeout);
+
+accept_ack1(#essl_socket{socket = LSocket, mod = P1_Mod}, Timeout)
+  when P1_Mod == ?MOD_FAST_TLS orelse P1_Mod == ?MOD_P1_TLS ->
+    ok = ranch_tcp:accept_ack(LSocket, Timeout);
+
+accept_ack1(#essl_socket{socket = LSocket, mod = ?MOD_TCP}, Timeout) ->
+    ok = ranch_tcp:accept_ack(LSocket, Timeout).
+
+
+peername(#essl_socket{socket = LSocket, mod = ?MOD_ETLS}) ->
+  ranch_etls:peername(LSocket);
+
+peername(#essl_socket{socket = LSocket, mod = ?MOD_SSL}) ->
+  ranch_ssl:peername(LSocket);
+
+peername(#essl_socket{socket = LSocket, mod = P1_Mod})
+  when P1_Mod == ?MOD_FAST_TLS orelse P1_Mod == ?MOD_P1_TLS ->
+  ranch_tcp:peername(LSocket#tlssock.tcpsock);
+
+peername(#essl_socket{socket = LSocket, mod = ?MOD_TCP}) ->
+  ranch_tcp:peername(LSocket).
+
+
+sockname(#essl_socket{socket = LSocket, mod = ?MOD_ETLS}) ->
+  ranch_etls:sockname(LSocket);
+
+sockname(#essl_socket{socket = LSocket, mod = ?MOD_SSL}) ->
+  ranch_ssl:sockname(LSocket);
+
+sockname(#essl_socket{socket = LSocket, mod = P1_Mod})
+  when P1_Mod == ?MOD_FAST_TLS orelse P1_Mod == ?MOD_P1_TLS ->
+  ranch_tcp:sockname(LSocket);
+
+sockname(#essl_socket{socket = LSocket, mod = ?MOD_TCP}) ->
+  ranch_tcp:sockname(LSocket).
+
+shutdown(#essl_socket{socket = LSocket, mod = ?MOD_ETLS}, Type) ->
+  ranch_etls:shutdown(LSocket, Type);
+
+shutdown(#essl_socket{socket = LSocket, mod = ?MOD_SSL}, Type) ->
+  ranch_ssl:shutdown(LSocket, Type);
+
+shutdown(#essl_socket{socket = LSocket, mod = P1_Mod}, Type)
+  when P1_Mod == ?MOD_FAST_TLS orelse P1_Mod == ?MOD_P1_TLS ->
+  ranch_tcp:shutdown(LSocket#tlssock.tcpsock, Type);
+
+shutdown(#essl_socket{socket = LSocket, mod = ?MOD_TCP}, Type) ->
+  ranch_tcp:shutdown(LSocket, Type).
+
+
+setopts(#essl_socket{socket = LSocket, mod = ?MOD_ETLS}, Options) ->
+  ranch_etls:setopts(LSocket, Options);
+
+setopts(#essl_socket{socket = LSocket, mod = ?MOD_SSL}, Options) ->
+  ranch_ssl:setopts(LSocket, Options);
+
+setopts(#essl_socket{socket = LSocket, mod = P1_Mod}, Options)
+  when P1_Mod == ?MOD_FAST_TLS orelse P1_Mod == ?MOD_P1_TLS ->
+  %%TCPSock = get_tcpsock(LSocket),
+  P1_Mod:setopts(LSocket, Options);
+
+setopts(#essl_socket{socket = LSocket, mod = ?MOD_TCP}, Options) ->
+  ranch_tcp:setopts(LSocket, Options).
+
+controlling_process(#essl_socket{socket = LSocket, mod = ?MOD_ETLS}, Pid) ->
+  ranch_etls:controlling_process(LSocket, Pid);
+
+controlling_process(#essl_socket{socket = LSocket, mod = ?MOD_SSL}, Pid) ->
+  ranch_ssl:controlling_process(LSocket, Pid);
+
+controlling_process(#essl_socket{socket = LSocket, mod = P1_Mod}, Pid)
+  when P1_Mod == ?MOD_FAST_TLS orelse P1_Mod == ?MOD_P1_TLS ->
+  P1_Mod:controlling_process(LSocket, Pid);
+
+controlling_process(#essl_socket{socket = LSocket, mod = ?MOD_TCP}, Pid) ->
+  ranch_tcp:controlling_process(LSocket, Pid).
+
+
+send(#essl_socket{socket = LSocket, mod = ?MOD_ETLS}, Data) ->
+  ranch_etls:send(LSocket, Data);
+
+send(#essl_socket{socket = LSocket, mod = ?MOD_SSL}, Data) ->
+  ranch_ssl:send(LSocket, Data);
+
+send(#essl_socket{socket = LSocket, mod = P1_Mod}, Data) 
+  when P1_Mod == ?MOD_FAST_TLS orelse P1_Mod == ?MOD_P1_TLS ->
+  P1_Mod:send(LSocket, Data);
+
+send(#essl_socket{socket = LSocket, mod = ?MOD_TCP}, Data) ->
+  ranch_tcp:send(LSocket, Data).
+
+recv(#essl_socket{socket = LSocket, mod = ?MOD_ETLS}, Size, Timeout) ->
+  ranch_etls:recv(LSocket, Size, Timeout);
+
+recv(#essl_socket{socket = LSocket, mod = ?MOD_SSL}, Size, Timeout) ->
+  ranch_ssl:recv(LSocket, Size, Timeout);
+
+recv(#essl_socket{socket = LSocket, mod = P1_Mod}, Size, Timeout) 
+  when P1_Mod == ?MOD_FAST_TLS orelse P1_Mod == ?MOD_P1_TLS ->
+  P1_Mod:recv(LSocket, Size, Timeout);
+
+recv(#essl_socket{socket = LSocket, mod = ?MOD_TCP}, Size, Timeout) ->
+  ranch_tcp:recv(LSocket, Size, Timeout).
+
+close(#essl_socket{socket = Socket, mod = ?MOD_ETLS}) ->
+  ranch_etls:close(Socket);
+close(#essl_socket{socket = Socket, mod = P1_Mod})
+  when P1_Mod == ?MOD_FAST_TLS orelse P1_Mod == ?MOD_P1_TLS ->
+  ranch_tcp:close(Socket#tlssock.tcpsock);
+
+close(#essl_socket{socket = Socket, mod = ?MOD_SSL}) ->
+  ranch_ssl:close(Socket);
+close(#essl_socket{socket = Socket, mod = ?MOD_TCP}) ->
+  ranch_tcp:close(Socket).
+
+

--- a/src/benchmarks/ranch_essl_server.erl
+++ b/src/benchmarks/ranch_essl_server.erl
@@ -1,0 +1,78 @@
+-module(ranch_essl_server).
+-behaviour(gen_server).
+-behaviour(ranch_protocol).
+
+%% API.
+-export([start_link/4]).
+
+%% gen_server.
+-export([init/1]).
+-export([handle_call/3]).
+-export([handle_cast/2]).
+-export([handle_info/2]).
+-export([terminate/2]).
+-export([code_change/3]).
+
+-define(TIMEOUT, 30000).
+
+-record(state, {socket, msg_count=0, total_size = 0}).
+-include("tls_bench.hrl").
+%% API.
+
+start_link(Ref, Socket, Transport, Opts) ->
+	{ok, proc_lib:spawn_link(?MODULE, init, [{Ref, Socket, Transport, Opts}])}.
+
+%% gen_server.
+
+%% This function is never called. We only define it so that
+%% we can use the -behaviour(gen_server) attribute.
+%init([]) -> {ok, undefined}.
+
+init({Ref, _Socket, Transport, _Opts = []}) ->
+	{ok, Socket1} = ranch:accept_ack(Ref),
+	ok = Transport:setopts(Socket1, [{active, once}]),
+	gen_server:enter_loop(?MODULE, [],
+		#state{socket=Socket1},
+		?TIMEOUT).
+
+handle_info({_Transport, _ImplSocket, Data}, #state{
+	socket = Socket, msg_count = Count, total_size = Total} = State) when byte_size(Data) > 1 ->
+	ranch_essl:setopts(Socket, [{active, once}]),
+        {NewCount, NewTotal} = case read_data(Socket, Data) of
+	   <<>> ->
+		{Count, Total};
+           D -> 
+		ranch_essl:send(Socket, D),
+		{Count + 1, Total + byte_size(D)} 
+        end,
+	{noreply, State#state{msg_count = NewCount, total_size = NewTotal}, ?TIMEOUT};
+handle_info({tcp_closed, _Socket}, State) ->
+	{stop, normal, State};
+handle_info({tcp_error, _, Reason}, State) ->
+	{stop, Reason, State};
+handle_info(timeout, State) ->
+	{stop, normal, State};
+handle_info(_Info, State) ->
+	{stop, normal, State}.
+
+handle_call(_Request, _From, State) ->
+	{reply, ok, State}.
+
+handle_cast(_Msg, State) ->
+	{noreply, State}.
+
+terminate(Reason, #state{msg_count = Count, total_size = Total, socket = Socket} = _State) ->
+   ?INFO_MSG("The connection ~p closed with '~p', received ~p messages, total size is ~p", [erlang:phash2(Socket), Reason, Count, Total]),
+	ok.
+
+code_change(_OldVsn, State, _Extra) ->
+	{ok, State}.
+
+
+read_data(#essl_socket{socket = TlsSocket, mod = P1_Mod} = _Socket, TlsData) 
+    when P1_Mod == ?MOD_FAST_TLS orelse P1_Mod == ?MOD_P1_TLS ->
+    {ok, Data} = P1_Mod:recv_data(TlsSocket, TlsData),
+    Data;
+read_data(_Socket, Data) ->
+    Data.
+

--- a/src/tls_bench.app.src
+++ b/src/tls_bench.app.src
@@ -2,7 +2,7 @@
     {description, "A framework for load testing the Erlang TLS and TCP libs"},
     {vsn, "1.0"},
     {registered, []},
-    {applications, [kernel, stdlib, ssl]},
+    {applications, [kernel, stdlib, ssl, ranch]},
     {included_applications, [p1_tls, fast_tls]},
     {mod, {tls_bench_app, []}},
     {env, []}

--- a/src/tls_bench_app.erl
+++ b/src/tls_bench_app.erl
@@ -7,15 +7,7 @@
 -export([start/2, stop/1]).
 
 start(_StartType, _StartArgs) ->
-    ok = start_servers(),
     tls_bench_sup:start_link().
 
 stop(_State) ->
     ok.
-
-start_servers() ->
-    ok = generic_server:start(?MOD_TCP),
-    ok = generic_server:start(?MOD_ETLS),
-    ok = generic_server:start(?MOD_FAST_TLS),
-    ok = generic_server:start(?MOD_P1_TLS),
-    ok = generic_server:start(?MOD_SSL).

--- a/src/tls_bench_sup.erl
+++ b/src/tls_bench_sup.erl
@@ -6,9 +6,60 @@
 
 -export([init/1]).
 
+-include("tls_bench.hrl"). 
+
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 init([]) ->
-    {ok, { {one_for_one, 5, 10}, []} }.
+    Children = ranch_listeners(),
+    {ok, { {one_for_one, 5, 10}, Children} }.
+
+ranch_sup() ->
+    {ranch_sup, {ranch_sup, start_link, []},
+     permanent, 5000, supervisor, [ranch_sup]}.
+
+ranch_listeners() ->
+    {ok, ServersConf} = application:get_env(tls_bench, servers),
+    {ok, RunningServers} = application:get_env(tls_bench, impls),
+    ListenOpts = tlsb_utils:lookup(listen_opt, ServersConf),
+    Acceptors = tlsb_utils:lookup(acceptors, ServersConf),
+    lists:map(fun(Impl) ->
+        ImplConfig = tlsb_utils:lookup(Impl, ServersConf),
+        Port = tlsb_utils:lookup(port, ImplConfig),
+	ChildName = atom_to_list(Impl) ++ "_bench",
+        start_app(Impl),
+        ImplOpts = impl_opts(Impl, ImplConfig, ServersConf),
+        print_opts(Impl, ListenOpts, Acceptors, Port, ImplOpts),
+	ranch:child_spec(ChildName, Acceptors, ranch_essl,
+                [
+		 {impl, Impl}, {port, Port},
+		 {max_connections, infinity}
+		 | ListenOpts ++ ImplOpts
+		],
+                ranch_essl_server, [])
+	end, RunningServers).
+
+impl_opts(gen_tcp, _ImplConfig, _SharedConfig) ->
+  [];
+
+impl_opts(SSL_Mod, ImplConfig, SharedConfig) when SSL_Mod == ?MOD_ETLS orelse SSL_Mod == ?MOD_SSL -> 
+  TLSOpts = tlsb_utils:lookup(tls_opt, SharedConfig),
+  ImplConfig ++ TLSOpts;
+
+impl_opts(P1_Mod, ImplConfig, SharedConfig) 
+  when P1_Mod == ?MOD_FAST_TLS orelse P1_Mod == ?MOD_P1_TLS ->
+  TLSOpts = tlsb_utils:lookup(tls_opt, SharedConfig),
+  [{tls_opt, TLSOpts ++ ImplConfig}].
+
+start_app(?MOD_TCP) -> ok;
+start_app(?MOD_SSL) -> application:ensure_all_started(ssl);
+start_app(?MOD_ETLS) -> application:ensure_all_started(etls);
+start_app(P1_Mod) when P1_Mod == ?MOD_FAST_TLS orelse P1_Mod == ?MOD_P1_TLS -> 
+  application:ensure_all_started(P1_Mod).
+
+print_opts(Impl, ListenOpts, Acceptors, Port, ImplOpts) ->
+    ?INFO_MSG("~p start listening on port ~p with ~p acceptors", [Impl, Port, Acceptors]),
+    ?INFO_MSG("~p listen opt: ~200p", [Impl, ListenOpts]),
+    ?INFO_MSG("~p tls options: ~200p", [Impl, ImplOpts]).
 

--- a/test/sys.config
+++ b/test/sys.config
@@ -1,19 +1,16 @@
 [
     {tls_bench, [
+        {impls, [gen_tcp, ssl, fast_tls, p1_tls]},
         {servers, [
 
-            {acceptors, 8},
+            {acceptors, 20},
 
             {listen_opt, [
-                binary,
-                {packet, raw},
-                {reuseaddr, true},
                 {send_timeout, 30000},
                 {send_timeout_close, true},
-                {nodelay, true},
-                {active, false},
                 {backlog, 5000},
                 {sndbuf, 60000},
+		{buffer, 60000},
                 {recbuf, 60000}
             ]},
 
@@ -24,41 +21,24 @@
                 {ciphers, ["AES128-GCM-SHA256"]}
             ]},
 
-            {tcp_opt, [
-                binary,
-                {packet, 0},
-                {nodelay, true},
-                {active, once},
-                {sndbuf, 60000},
-                {recbuf, 60000}
-            ]},
-
             {ssl, [
                 {port, 4000},
-                {tls_opt, [
-                    {verify, verify_none}
-                ]}
+                {verify, verify_none}
             ]},
 
             {p1_tls, [
                 {port, 5000},
-                {tls_opt, [
-                    verify_none, compression_none
-                ]}
+                {verify_none, compression_none}
             ]},
 
             {fast_tls, [
                 {port, 6000},
-                {tls_opt, [
-                    verify_none, compression_none
-                ]}
+                {verify_none, compression_none}
             ]},
 
             {etls, [
                 {port, 7000},
-                {tls_opt, [
                     {verify, verify_none}
-                ]}
             ]},
 
             {gen_tcp, [


### PR DESCRIPTION
-ranch integration;
-stats (number and the total size of incoming messages on server side per connection);
-config has been changed to remove params that are default for ranch;
-the implementations to test are put into the sys.config ('impls' param);
-etls is removed from rebar.config, but it should work if put back, as etls is implemented in ranch_essl.